### PR TITLE
fix: can not save new chat

### DIFF
--- a/app/_components/ChatInputBox.tsx
+++ b/app/_components/ChatInputBox.tsx
@@ -30,8 +30,6 @@ function ChatInputBox() {
   const isLoadingHistory = useRef(false);
   // 追踪用户是否主动发送了消息（用于区分新聊天和历史会话切换）
   const hasUserSentMessage = useRef(false);
-  // 追踪是否已经保存过当前对话（避免重复保存）
-  const hasSavedConversation = useRef(false);
 
   useEffect(() => {
     const urlChatId = params.get("chatId");
@@ -61,42 +59,43 @@ function ChatInputBox() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params]); // 只依赖 params
 
+  // 使用函数式更新来避免闭包陷阱
   useEffect(() => {
     const newChatId = params.get("chatId");
-    const oldChatId = chatId;
 
-    console.log("🔍 Params useEffect triggered:", { newChatId, oldChatId });
+    // console.log("🔍 Params useEffect triggered:", { newChatId });
 
-    setChatId(newChatId || ""); // 如果没有 chatId，设置为空字符串
+    setChatId((prev) => {
+      const oldChatId = prev;
 
-    // 只有在真正切换会话时才重置标记（从有chatId切换到另一个chatId，或者从有chatId切换到无chatId）
-    // 如果是从无chatId到有chatId（创建新会话），不要重置标记
-    if (oldChatId && oldChatId !== (newChatId || "")) {
-      console.log("🔄 Switching between conversations, resetting flags");
-      hasCreatedNewChat.current = false;
-      hasUserSentMessage.current = false;
-      hasSavedConversation.current = false;
-    } else if (!oldChatId && !newChatId) {
-      // 如果都是在无chatId状态，也重置标记（比如刷新页面）
-      console.log("🔄 No chatId in both states, resetting flags");
-      hasCreatedNewChat.current = false;
-      hasUserSentMessage.current = false;
-      hasSavedConversation.current = false;
-    } else {
-      console.log("🔄 Creating new chatId, keeping user flags");
-      // 创建新chatId时，保持用户发送消息的标记
-      hasCreatedNewChat.current = false;
-      // 不重置 hasUserSentMessage 和 hasSavedConversation
-    }
-  }, [params, chatId]);
+      // console.log("🔍 ChatId comparison:", { oldChatId, newChatId });
+
+      // 只有在真正切换会话时才重置标记（从有chatId切换到另一个chatId，或者从有chatId切换到无chatId）
+      // 如果是从无chatId到有chatId（创建新会话），不要重置标记
+      if (oldChatId && oldChatId !== (newChatId || "")) {
+        // console.log("🔄 Switching between conversations, resetting flags");
+        hasCreatedNewChat.current = false;
+        hasUserSentMessage.current = false;
+      } else if (!oldChatId && !newChatId) {
+        // 如果都是在无chatId状态，也重置标记（比如刷新页面）
+        // console.log("🔄 No chatId in both states, resetting flags");
+        hasCreatedNewChat.current = false;
+        hasUserSentMessage.current = false;
+      } else {
+        // console.log("🔄 Creating new chatId, keeping user flags");
+        hasCreatedNewChat.current = false;
+        // 不重置 hasUserSentMessage，保持用户发送消息的标记
+      }
+
+      return newChatId || "";
+    });
+  }, [params]);
 
   const handleSend = () => {
     if (inputValue.trim() === "") return;
 
     // 标记用户主动发送了消息
     hasUserSentMessage.current = true;
-    // 重置保存标记，因为这是新的对话内容
-    hasSavedConversation.current = false;
 
     // 1. Add user message to all enabled models
     setMessages((prev) => {
@@ -204,7 +203,7 @@ function ChatInputBox() {
     if (!chatId || chatId === "" || !userDetail) {
       return;
     }
-    console.log("begin saveConversation", chatId);
+    console.log("begin saveConversation", chatId, messages);
 
     const docRef = doc(db, "chatHistory", chatId);
     const docSnap = await getDoc(docRef);
@@ -219,9 +218,6 @@ function ChatInputBox() {
       createdAt,
       updatedAt: new Date(),
     });
-
-    // 标记已经保存过
-    hasSavedConversation.current = true;
 
     // 保存完成后触发回调
     if (onConversationSaved) {
@@ -256,12 +252,6 @@ function ChatInputBox() {
         return;
       }
 
-      // 避免重复保存
-      if (hasSavedConversation.current) {
-        console.log("💾 Conversation already saved, skipping");
-        return;
-      }
-
       console.log("💾 User sent message, saving conversation");
       saveConversation();
     }
@@ -271,12 +261,7 @@ function ChatInputBox() {
   // 当 chatId 创建后，如果有用户发送的消息，立即保存对话
   useEffect(() => {
     // 只有在用户发送了消息且有 chatId 且还没有保存过时才保存
-    if (
-      hasUserSentMessage.current &&
-      chatId &&
-      chatId !== "" &&
-      !hasSavedConversation.current
-    ) {
+    if (hasUserSentMessage.current && chatId && chatId !== "") {
       console.log("💾 ChatId created, saving conversation immediately");
       saveConversation();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Tracks whether the user has sent a message and whether a conversation has been created.
  - Automatically saves a conversation once a chat becomes available after a user message.
  - Adds clearer logging around save gating and chat state transitions.

- Bug Fixes
  - Prevents premature or duplicate conversation saves.
  - Preserves user-sent state when creating a new chat and resets correctly on session switches.
  - Avoids saving during initial history load or when messages are empty/null; requires valid chat to save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->